### PR TITLE
Resolve mac address format issue when running on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function arpDevices(range, callback) {
                 } else if (osType === 'Darwin') {
                   host.mac = stdout.split(' ')[3];
                 } else {
-                  host.mac = stdout.split('\n')[3].replace(/ +/g, ' ').replace('-', ':').split(' ')[2];
+                  host.mac = stdout.split('\n')[3].replace(/ +/g, ' ').split('-').join(':').split(' ')[2];
                 }
 
                 var known = macLookup(host.mac);


### PR DESCRIPTION
replace() replace only the first occurrence of the keyword. If made mac address be resolve from e.g. "00-11-32-91-38-14" to "00:11-32-91-38-14". Changed the code to split + join to replace all occurrences.

Before
![InkedScreenshot 2021-04-23 191242_LI](https://user-images.githubusercontent.com/4076165/115871313-f515b680-a472-11eb-8473-18562c370cc0.jpg)

After
![InkedScreenshot 2021-04-23 194907_LI](https://user-images.githubusercontent.com/4076165/115871324-f941d400-a472-11eb-9dfb-c50d40aa045a.jpg)
